### PR TITLE
LUT-29292: Upgrade jjwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-![](http://dev.lutece.paris.fr/jenkins/buildStatus/icon?job=auth-plugin-oauth2-deploy)
+![](https://dev.lutece.paris.fr/jenkins/buildStatus/icon?job=auth-plugin-oauth2-deploy)
+[![Alerte](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece.plugins%3Aplugin-oauth2&metric=alert_status)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece.plugins%3Aplugin-oauth2)
+[![Line of code](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece.plugins%3Aplugin-oauth2&metric=ncloc)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece.plugins%3Aplugin-oauth2)
+[![Coverage](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece.plugins%3Aplugin-oauth2&metric=coverage)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece.plugins%3Aplugin-oauth2)
+
 # Plugin Oauth2
 
-![](http://dev.lutece.paris.fr/plugins/plugin-oauth2/images/oauth2.png)
+![](https://dev.lutece.paris.fr/plugins/plugin-oauth2/images/oauth2.png)
 
 ## Introduction
-
 
 Ce plugin permet d'acceder à des ressources via le protocole oauth2. Grâce à l'authentification par le biais d'un fournisseur d'identités Oauth2,un fournisseur de service peut ensuite accéder à des ressources liées à l'utilisateur (et avec son consentement).
 
@@ -22,6 +25,7 @@ Il faut notamment paramétrer :
  
 * Les adresses des WebServices la plate-forme Oauth2 cible (end points)
 * Vos identifiants (id, secret) qui vous auront été fournit par le service oauth2 utilisé
+* Si le serveur utilise JWT et que les tokens sont signés, alors le paramètre signatureAlgorithmName soit être renseigné. Si les tokens nesont pas signés, alors le paramètre signatureAlgorithmName ne doit pas être renseigné
 * L'adresse du Callback du plugin (NB : Cette adresse doit être enregistrée et associée à votre ID Client auprès du service Oauth2 utilisé.
 doit ensuite être paramétré avec les informationsdu service client (id, secret et callback) :
 
@@ -35,8 +39,8 @@ doit ensuite être paramétré avec les informationsdu service client (id, secre
                                   value=" **** à renseigner **** "/>
         <property name="tokenEndpointUri" value=" **** à renseigner **** "/>
         <property name="logoutEndpointUri" value=" **** à renseigner **** "/>
-        <property name="enableJwtParser" value="true"  ****True si le serveur utilise JWT ****   >
-        
+        <property name="enableJwtParser" value="****true si le serveur utilise JWT ****" />
+        <property name="signatureAlgorithmName" value="HS512"/>
     </bean> 
     
     <bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf">
@@ -99,7 +103,7 @@ doit ensuite être paramétré avec les informationsdu service client (id, secre
 
 
 
-[Maven documentation and reports](http://dev.lutece.paris.fr/plugins/plugin-oauth2/)
+[Maven documentation and reports](https://dev.lutece.paris.fr/plugins/plugin-oauth2/)
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>fr.paris.lutece.plugins</groupId>
     <artifactId>plugin-oauth2</artifactId>
     <packaging>lutece-plugin</packaging>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Lutece oauth2 plugin</name>
 
     <repositories>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>fr.paris.lutece.plugins</groupId>
             <artifactId>library-httpaccess</artifactId>
-            <version>[3.0.0-SNAPSHOT,)</version>
+            <version>3.0.2</version>
         </dependency>
         
         <!-- Used by MITRE JWT Parser implementation -->
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
-            <version>0.5</version>
+            <version>0.12.6</version>
         </dependency>
       
     </dependencies>

--- a/src/java/fr/paris/lutece/plugins/oauth2/business/AuthClientConf.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/business/AuthClientConf.java
@@ -112,16 +112,6 @@ public class AuthClientConf implements Serializable
         _strRedirectUri = strRedirectUri;
     }
 
-    /**
-     * Return IDToken signed response Algorithm
-     * 
-     * @return The IDToken signed response Algorithm
-     */
-    public Algorithm getIdTokenSignedResponseAlg( )
-    {
-        return null;
-    }
-
 	public boolean isPublic() {
 		return _bPublic;
 	}

--- a/src/java/fr/paris/lutece/plugins/oauth2/business/AuthServerConf.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/business/AuthServerConf.java
@@ -47,6 +47,7 @@ public class AuthServerConf implements Serializable
     private String _strTokenEndpointUri;
     private String _strLogoutEndpointUri;
     private boolean _bEnableJwtParser;
+    private String _signatureAlgorithmName;
 
     /**
      * 
@@ -168,6 +169,32 @@ public class AuthServerConf implements Serializable
     public void setEnableJwtParser( boolean _bEnableJwtParser )
     {
         this._bEnableJwtParser = _bEnableJwtParser;
+    }
+
+    /**
+     * The signature algorithm code. If present and if the jwt parser is enabled, the token will be required to have been signed using this algorithm. If
+     * <code>null</code>, the token must not have been signed.
+     * 
+     * @return the signature algorithm code
+     * @since 2.0.0
+     */
+    public String getSignatureAlgorithmName( )
+    {
+        return _signatureAlgorithmName;
+    }
+
+    /**
+     * Sets the signature algorithm code. If not <code>null</code> and if the jwt parser is enabled, the token will be required to have been signed using this
+     * algorithm. If <code>null</code>, the token must not have been signed.
+     * 
+     * @see https://www.rfc-editor.org/rfc/rfc7518.html#section-7.1
+     * @param signatureAlgorithm
+     *            the signature algorithm code
+     * @since 2.0.0
+     */
+    public void setSignatureAlgorithmName( String signatureAlgorithmName )
+    {
+        this._signatureAlgorithmName = signatureAlgorithmName;
     }
 
 }

--- a/src/java/fr/paris/lutece/plugins/oauth2/business/IDToken.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/business/IDToken.java
@@ -33,12 +33,14 @@
  */
 package fr.paris.lutece.plugins.oauth2.business;
 
+import java.util.Set;
+
 /**
  * IDToken : informations provided by a JWT (Json Web Token)
  */
 public class IDToken
 {
-    private String _strAudience;
+    private Set<String> _strAudience;
     private String _strExpiration;
     private String _strIssueAt;
     private String _strIssuer;
@@ -52,7 +54,7 @@ public class IDToken
      * 
      * @return The Audience
      */
-    public String getAudience( )
+    public Set<String> getAudience( )
     {
         return _strAudience;
     }
@@ -63,7 +65,7 @@ public class IDToken
      * @param strAudience
      *            The Audience
      */
-    public void setAudience( String strAudience )
+    public void setAudience( Set<String> strAudience )
     {
         _strAudience = strAudience;
     }

--- a/src/java/fr/paris/lutece/plugins/oauth2/jwt/MitreJWTParser.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/jwt/MitreJWTParser.java
@@ -46,12 +46,14 @@ import fr.paris.lutece.plugins.oauth2.business.AuthServerConf;
 import fr.paris.lutece.plugins.oauth2.business.IDToken;
 import fr.paris.lutece.plugins.oauth2.business.Token;
 import fr.paris.lutece.plugins.oauth2.web.Constants;
+import io.jsonwebtoken.lang.Collections;
 
 import org.apache.log4j.Logger;
 
 import java.text.ParseException;
 
 import java.util.Date;
+import java.util.HashSet;
 
 /**
  * MitreJWTParser
@@ -267,7 +269,7 @@ public class MitreJWTParser implements JWTParser
         idToken.setExpiration( String.valueOf( idClaims.getExpirationTime( ).getTime( ) / 1000L ) );
         idToken.setIssueAt( String.valueOf( idClaims.getIssueTime( ).getTime( ) / 1000L ) );
         idToken.setIssuer( idClaims.getIssuer( ) );
-        idToken.setAudience( idClaims.getAudience( ).get( 0 ) );
+        idToken.setAudience( Collections.immutable( new HashSet<>( idClaims.getAudience( ) ) ) );
         idToken.setAcr( strAcr );
         logger.debug( "ID Token retrieved : " + idToken );
 

--- a/src/java/fr/paris/lutece/plugins/oauth2/jwt/MitreJWTParser.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/jwt/MitreJWTParser.java
@@ -98,9 +98,9 @@ public class MitreJWTParser implements JWTParser
 
         Algorithm tokenAlg = jwt.getHeader( ).getAlgorithm( );
 
-        Algorithm clientAlg = clientConfig.getIdTokenSignedResponseAlg( );
+        Algorithm clientAlg = JWSAlgorithm.parse( serverConfig.getSignatureAlgorithmName( ) );
 
-        if ( clientAlg != null )
+        if ( serverConfig.getSignatureAlgorithmName( ) != null )
         {
             if ( !clientAlg.equals( tokenAlg ) )
             {
@@ -112,7 +112,7 @@ public class MitreJWTParser implements JWTParser
         {
             logger.debug( "ID token is a Plain JWT" );
 
-            if ( clientAlg == null )
+            if ( serverConfig.getSignatureAlgorithmName( ) != null )
             {
                 throw new TokenValidationException( "Unsigned ID tokens can only be used if explicitly configured in client." );
             }

--- a/src/site/fr/xdoc/index.xml
+++ b/src/site/fr/xdoc/index.xml
@@ -39,9 +39,12 @@
             <ul>
                 <li>Les adresses des WebServices la plate-forme Oauth2 cible (end points)</li>
                 <li>Vos identifiants  (id, secret) qui vous auront été fournit par le service oauth2 utilisé</li>
+                <li>Si le serveur utilise JWT et que les tokens sont signés, alors le paramètre
+                signatureAlgorithmName soit être renseigné. Si les tokens ne
+                sont pas signés, alors le paramètre signatureAlgorithmName ne doit pas être renseigné</li>
                 <li>L'adresse du Callback du plugin (NB : Cette adresse doit être enregistrée et 
                 associée à votre ID Client auprès du service Oauth2 utilisé. 
-      			</li>
+                </li>
             </ul>
             
            doit ensuite être paramétré avec les informations 
@@ -57,8 +60,8 @@
                                   value=" **** à renseigner **** "/&gt;
         &lt;property name="tokenEndpointUri" value=" **** à renseigner **** "/&gt;
         &lt;property name="logoutEndpointUri" value=" **** à renseigner **** "/&gt;
-        &lt;property name="enableJwtParser" value="true"  ****True si le serveur utilise JWT ****   &gt;
-        
+        &lt;property name="enableJwtParser" value="****true si le serveur utilise JWT ****" /&gt;
+        &lt;property name="signatureAlgorithmName" value="HS512"/&gt;
     &lt;/bean&gt; 
     
     &lt;bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf"&gt;
@@ -116,10 +119,10 @@
                             <code>WEB-INF/conf/config.properties</code> dans la rubrique LOGGERS :
                             <p>                       
                             <div class="source">
-							<pre>
-							log4j.logger.lutece.oauth2=DEBUG, Console
-							</pre>
-							  </div>
+                            <pre>
+                            log4j.logger.lutece.oauth2=DEBUG, Console
+                            </pre>
+                              </div>
                             </p>
                         </li>
                     </ul>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -39,6 +39,9 @@
             <ul>
                 <li>Les adresses des WebServices la plate-forme Oauth2 cible (end points)</li>
                 <li>Vos identifiants  (id, secret) qui vous auront été fournit par le service oauth2 utilisé</li>
+                <li>Si le serveur utilise JWT et que les tokens sont signés, alors le paramètre
+                signatureAlgorithmName soit être renseigné. Si les tokens ne
+                sont pas signés, alors le paramètre signatureAlgorithmName ne doit pas être renseigné</li>
                 <li>L'adresse du Callback du plugin (NB : Cette adresse doit être enregistrée et 
                 associée à votre ID Client auprès du service Oauth2 utilisé. 
       			</li>
@@ -57,8 +60,8 @@
                                   value=" **** à renseigner **** "/&gt;
         &lt;property name="tokenEndpointUri" value=" **** à renseigner **** "/&gt;
         &lt;property name="logoutEndpointUri" value=" **** à renseigner **** "/&gt;
-        &lt;property name="enableJwtParser" value="true"  ****True si le serveur utilise JWT ****   &gt;
-        
+        &lt;property name="enableJwtParser" value="****true si le serveur utilise JWT ****" /&gt;
+        &lt;property name="signatureAlgorithmName" value="HS512"/&gt;
     &lt;/bean&gt; 
     
     &lt;bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf"&gt;

--- a/webapp/WEB-INF/conf/plugins/oauth2_context.xml
+++ b/webapp/WEB-INF/conf/plugins/oauth2_context.xml
@@ -16,6 +16,7 @@
         <property name="tokenEndpointUri" value="https://fcp.integ01.dev-oauth2.fr/api/v1/token"/>
         <property name="logoutEndpointUri" value="https://fcp.integ01.dev-oauth2.fr/api/v1/logout"/>
         <property name="enableJwtParser" value="true"/>
+        <property name="signatureAlgorithmName" value="HS512"/>
       </bean> 
     
     <bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf">


### PR DESCRIPTION
Use the same version as library-signrequest
Bump the version to 2.0.0 because of an incompatible chnage on the IDToken object. The audience field is a set of values instead of a single value.