### PR TITLE
LUT-29463: Allow configuration via OpenID Connect Discovery 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,34 @@ Ce plugin est également utilisé par le Module [MyLutece Oauth2](https://github
 
 Configurer le fichier de context du plugin (WEB-INF/conf/plugins/oauth2_context.xml).
 
-Il faut notamment paramétrer :
+Pour la configuration client, utilisez une configuration du type
+
+```
+           
+    <bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf">
+        <property name="clientId" value=" **** à renseigner **** "/>
+        <property name="clientSecret" value=" **** à renseigner **** "/>
+        <property name="redirectUri" value=" **** à renseigner **** "/>
+    </bean>       
+
+```
+
+Pour la configuration serveur, si le serveur OAuth supporte OpenID Connect, alors seul le paramètre `issuer` est requis, en utilisant la class de configuration `fr.paris.lutece.plugins.oauth2.business.OIDCAuthServerConf` 
+
+```
+
+    <bean id="oauth2.server" class="fr.paris.lutece.plugins.oauth2.business.OIDCAuthServerConf">
+        <property name="issuer" value="${oauth2.issuer} "/>
+    </bean> 
+
+```
+
+La variable `oauth2.issuer` peut être définie dans un fichier de properties afin d'être adaptée aux différents environnements.
+
+Une configuration directe est également possible, en utilisant la classe `fr.paris.lutece.plugins.oauth2.business.AuthServerConf` :
  
 * Les adresses des WebServices la plate-forme Oauth2 cible (end points)
-* Vos identifiants (id, secret) qui vous auront été fournit par le service oauth2 utilisé
-* Si le serveur utilise JWT et que les tokens sont signés, alors le paramètre signatureAlgorithmName soit être renseigné. Si les tokens nesont pas signés, alors le paramètre signatureAlgorithmName ne doit pas être renseigné
+* Si le serveur utilise JWT et que les tokens sont signés, alors le paramètre IDTokenSignatureAlgorithmNames soit être renseigné. Si les tokens nesont pas signés, alors le paramètre IDTokenSignatureAlgorithmNames ne doit pas être renseigné
 * Si le paramètre jwksEndpointUri est renseigné, les clefs de signature des token sont téléchargées depuis cette adresse, qui doit pointer vers un fichier JWKS.
 * L'adresse du Callback du plugin (NB : Cette adresse doit être enregistrée et associée à votre ID Client auprès du service Oauth2 utilisé.
 doit ensuite être paramétré avec les informationsdu service client (id, secret et callback) :
@@ -41,18 +64,14 @@ doit ensuite être paramétré avec les informationsdu service client (id, secre
         <property name="tokenEndpointUri" value=" **** à renseigner **** "/>
         <property name="logoutEndpointUri" value=" **** à renseigner **** "/>
         <property name="enableJwtParser" value="****true si le serveur utilise JWT ****" />
-        <property name="signatureAlgorithmName" value="HS512"/>
+        <property name="IDTokenSignatureAlgorithmNames">
+            <set><value>HS512<value></set>
+        </property>
         <property name="jwksEndpointUri" value=" **** à renseigner **** "/>
-    </bean> 
-    
-    <bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf">
-        <property name="clientId" value=" **** à renseigner **** "/>
-        <property name="clientSecret" value=" **** à renseigner **** "/>
-        <property name="redirectUri" value=" **** à renseigner **** "/>
-    </bean>       
+    </bean>  
     
     <bean id="oauth2.callbackHandler" class="fr.paris.lutece.plugins.oauth2.web.CallbackHandler" >
-      ;<property name="authServerConf" ref="oauth2.server">
+       <property name="authServerConf" ref="oauth2.server">
        <property name="authClientConf" ref="oauth2.client">
        <property name="jWTParser" ref="oauth2.jWTParser"">
     </bean>      

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>fr.paris.lutece.plugins</groupId>
             <artifactId>library-httpaccess</artifactId>
-            <version>3.0.2</version>
+            <version>[3.0.3-SNAPSHOT,)</version>
         </dependency>
         
         <!-- Used by MITRE JWT Parser implementation -->
@@ -42,7 +42,11 @@
             <artifactId>jjwt</artifactId>
             <version>0.12.6</version>
         </dependency>
-      
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5-cache</artifactId>
+            <version>5.4.1</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/java/fr/paris/lutece/plugins/oauth2/business/AuthServerConf.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/business/AuthServerConf.java
@@ -34,6 +34,8 @@
 package fr.paris.lutece.plugins.oauth2.business;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * ServerConfiguration
@@ -47,7 +49,7 @@ public class AuthServerConf implements Serializable
     private String _strTokenEndpointUri;
     private String _strLogoutEndpointUri;
     private boolean _bEnableJwtParser;
-    private String _signatureAlgorithmName;
+    private Set<String> _signatureAlgorithmNames;
     private String _strJwksEndpointUri;
 
     /**
@@ -179,9 +181,9 @@ public class AuthServerConf implements Serializable
      * @return the signature algorithm code
      * @since 2.0.0
      */
-    public String getSignatureAlgorithmName( )
+    public Set<String> getSignatureAlgorithmNames( )
     {
-        return _signatureAlgorithmName;
+        return _signatureAlgorithmNames;
     }
 
     /**
@@ -195,7 +197,21 @@ public class AuthServerConf implements Serializable
      */
     public void setSignatureAlgorithmName( String signatureAlgorithmName )
     {
-        this._signatureAlgorithmName = signatureAlgorithmName;
+        this._signatureAlgorithmNames = Collections.singleton( signatureAlgorithmName );
+    }
+
+    /**
+     * Sets the signature algorithm code set. If not <code>null</code> and if the jwt parser is enabled, the token will be required to have been signed using
+     * one of these algorithms. If <code>null</code>, the token must not have been signed.
+     * 
+     * @see https://www.rfc-editor.org/rfc/rfc7518.html#section-7.1
+     * @param signatureAlgorithm
+     *            the signature algorithm code
+     * @since 2.0.0
+     */
+    public void setSignatureAlgorithmNames( Set<String> signatureAlgorithmNames )
+    {
+        this._signatureAlgorithmNames = signatureAlgorithmNames;
     }
 
     /**

--- a/src/java/fr/paris/lutece/plugins/oauth2/business/AuthServerConf.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/business/AuthServerConf.java
@@ -34,7 +34,6 @@
 package fr.paris.lutece.plugins.oauth2.business;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -49,7 +48,7 @@ public class AuthServerConf implements Serializable
     private String _strTokenEndpointUri;
     private String _strLogoutEndpointUri;
     private boolean _bEnableJwtParser;
-    private Set<String> _signatureAlgorithmNames;
+    private Set<String> _idTokenSignatureAlgorithmNames;
     private String _strJwksEndpointUri;
 
     /**
@@ -175,43 +174,29 @@ public class AuthServerConf implements Serializable
     }
 
     /**
-     * The signature algorithm code. If present and if the jwt parser is enabled, the token will be required to have been signed using this algorithm. If
-     * <code>null</code>, the token must not have been signed.
+     * The signature algorithm code for ID Token. If present and if the jwt parser is enabled, the token will be required to have been signed using this
+     * algorithm. If <code>null</code>, the token must not have been signed.
      * 
      * @return the signature algorithm code
      * @since 2.0.0
      */
-    public Set<String> getSignatureAlgorithmNames( )
+    public Set<String> getIDTokenSignatureAlgorithmNames( )
     {
-        return _signatureAlgorithmNames;
+        return _idTokenSignatureAlgorithmNames;
     }
 
     /**
-     * Sets the signature algorithm code. If not <code>null</code> and if the jwt parser is enabled, the token will be required to have been signed using this
-     * algorithm. If <code>null</code>, the token must not have been signed.
+     * Sets the signature algorithm code set for ID Token. If not <code>null</code> and if the jwt parser is enabled, the token will be required to have been
+     * signed using one of these algorithms. If <code>null</code>, the token must not have been signed.
      * 
      * @see https://www.rfc-editor.org/rfc/rfc7518.html#section-7.1
      * @param signatureAlgorithm
      *            the signature algorithm code
      * @since 2.0.0
      */
-    public void setSignatureAlgorithmName( String signatureAlgorithmName )
+    public void setIDTokenSignatureAlgorithmNames( Set<String> signatureAlgorithmNames )
     {
-        this._signatureAlgorithmNames = Collections.singleton( signatureAlgorithmName );
-    }
-
-    /**
-     * Sets the signature algorithm code set. If not <code>null</code> and if the jwt parser is enabled, the token will be required to have been signed using
-     * one of these algorithms. If <code>null</code>, the token must not have been signed.
-     * 
-     * @see https://www.rfc-editor.org/rfc/rfc7518.html#section-7.1
-     * @param signatureAlgorithm
-     *            the signature algorithm code
-     * @since 2.0.0
-     */
-    public void setSignatureAlgorithmNames( Set<String> signatureAlgorithmNames )
-    {
-        this._signatureAlgorithmNames = signatureAlgorithmNames;
+        this._idTokenSignatureAlgorithmNames = signatureAlgorithmNames;
     }
 
     /**

--- a/src/java/fr/paris/lutece/plugins/oauth2/business/OIDCAuthServerConf.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/business/OIDCAuthServerConf.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2002-2025, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.oauth2.business;
+
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import fr.paris.lutece.plugins.oauth2.service.CachingHttpAccessService;
+import fr.paris.lutece.portal.service.util.AppException;
+import fr.paris.lutece.util.httpaccess.HttpAccess;
+import fr.paris.lutece.util.httpaccess.HttpAccessException;
+import fr.paris.lutece.util.httpaccess.HttpAccessService;
+import fr.paris.lutece.util.httpaccess.PropertiesHttpClientConfiguration;
+
+/**
+ * Server configuration for OpenID Connect
+ * 
+ * @since 2.0.0
+ */
+public class OIDCAuthServerConf extends AuthServerConf
+{
+    private static final long serialVersionUID = 3459341547945895738L;
+    private static final String WELLKNOWN_PATH = ".well-known/openid-configuration";
+
+    private final HttpAccess _httpAccess;
+    private final ObjectMapper _mapper;
+
+    public OIDCAuthServerConf( )
+    {
+        HttpAccessService accessService = new CachingHttpAccessService( new PropertiesHttpClientConfiguration( ) );
+        this._httpAccess = new HttpAccess( accessService );
+        this._mapper = new ObjectMapper( );
+        this._mapper.configure( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false );
+    }
+
+    @Override
+    public boolean isEnableJwtParser( )
+    {
+        return true;
+    }
+
+    @Override
+    public String getAuthorizationEndpointUri( )
+    {
+        if ( super.getAuthorizationEndpointUri( ) != null )
+        {
+            return super.getAuthorizationEndpointUri( );
+        }
+        return getOpenidConfiguration( ).getAuthorizationEndpoint( );
+    }
+
+    @Override
+    public String getTokenEndpointUri( )
+    {
+        if ( super.getTokenEndpointUri( ) != null )
+        {
+            return super.getTokenEndpointUri( );
+        }
+        return getOpenidConfiguration( ).getTokenEndpoint( );
+    }
+
+    @Override
+    public Set<String> getIDTokenSignatureAlgorithmNames( )
+    {
+        if ( super.getIDTokenSignatureAlgorithmNames( ) != null )
+        {
+            return super.getIDTokenSignatureAlgorithmNames( );
+        }
+        return Set.of( getOpenidConfiguration( ).getIDTokenSigningAlgValuesSupported( ) );
+    }
+
+    @Override
+    public String getJwksEndpointUri( )
+    {
+        if ( super.getJwksEndpointUri( ) != null )
+        {
+            return super.getJwksEndpointUri( );
+        }
+        return getOpenidConfiguration( ).getJwksURI( );
+    }
+
+    @Override
+    public String getLogoutEndpointUri( )
+    {
+        if ( super.getLogoutEndpointUri( ) != null )
+        {
+            return super.getLogoutEndpointUri( );
+        }
+        return getOpenidConfiguration( ).getEndSessionEndpoint( );
+    }
+
+    private OpenIDConfiguration getOpenidConfiguration( )
+    {
+        String issuer = getIssuer( );
+        Objects.requireNonNull( issuer, "issuer must not be null" );
+        if ( !issuer.startsWith( "https" ) )
+        {
+            throw new UnsupportedOperationException( "The issuer must start with https, but is " + issuer );
+        }
+        String strConfURL;
+        if ( issuer.endsWith( "/" ) )
+        {
+            strConfURL = issuer + WELLKNOWN_PATH;
+        }
+        else
+        {
+            strConfURL = issuer + "/" + WELLKNOWN_PATH;
+        }
+        try
+        {
+            String strConfiguration = _httpAccess.doGet( strConfURL );
+            OpenIDConfiguration res = this._mapper.readValue( strConfiguration, OpenIDConfiguration.class );
+            res.validate( issuer );
+            return res;
+        }
+        catch( HttpAccessException | JsonProcessingException e )
+        {
+            throw new AppException( e.getMessage( ), e );
+        }
+    }
+}

--- a/src/java/fr/paris/lutece/plugins/oauth2/business/OpenIDConfiguration.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/business/OpenIDConfiguration.java
@@ -1,0 +1,645 @@
+/*
+ * Copyright (c) 2002-2025, City of Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.oauth2.business;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import fr.paris.lutece.portal.service.util.AppException;
+
+/**
+ * OpenID Configuration
+ * 
+ * @see https://openid.net/specs/openid-connect-discovery-1_0.html
+ * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+ * @since 2.0.0
+ */
+public class OpenIDConfiguration
+{
+    private String _strIssuer;
+    private String _strAuthorizationEndpoint;
+    private String _strTokenEndpoint;
+    private String _strUserinfoEndpoint;
+    private String _strJwksURI;
+    private String _strRegistrationEndpoint;
+    private String [ ] _scopesSupported;
+    private String [ ] _responseTypesSupported;
+    private String [ ] _responseModesSupported;
+    private String [ ] _grantTypesSupported;
+    private String [ ] _acrValuesSupported;
+    private String [ ] _subjectTypesSupported;
+    private String [ ] _idTokenSigningAlgValuesSupported;
+    private String [ ] _idTokenEncryptionAlgValuesSupported;
+    private String [ ] _idTokenEncryptionEncValuesSupported;
+    private String [ ] _userinfoSigningAlgValuesSupported;
+    private String [ ] _userinfoEncryptionAlgValuesSupported;
+    private String [ ] _userinfoEncryptionEncValuesSupported;
+    private String [ ] _requestObjectSigningAlgValuesSupported;
+    private String [ ] _requestObjectEncryptionAlgValuesSupported;
+    private String [ ] _requestObjectEncryptionEncValuesSupported;
+    private String [ ] _tokenEndpointAuthMethodsSupported;
+    private String [ ] _tokenEndpointAuthSigningAlgValuesSupported;
+    private String [ ] _displayValuesSupported;
+    private String [ ] _claimTypesSupported;
+    private String [ ] _claimsSupported;
+    private String _serviceDocumentation;
+    private String [ ] _claimsLocalesSupported;
+    private String [ ] _uiLocalesSupported;
+    private boolean _claimsParameterSupported;
+    private boolean _requestParameterSupported;
+    private boolean _requestUIRParameterSupported = true;
+    private boolean _requireRequestUIRRegistration;
+    private String _opPolicyURI;
+    private String _opTOSURI;
+    private String _strEndSessionEndpoint;
+
+    public String getIssuer( )
+    {
+        return _strIssuer;
+    }
+
+    public void setIssuer( String strIssuer )
+    {
+        _strIssuer = strIssuer;
+    }
+
+    @JsonProperty( "authorization_endpoint" )
+    public String getAuthorizationEndpoint( )
+    {
+        return _strAuthorizationEndpoint;
+    }
+
+    @JsonProperty( "authorization_endpoint" )
+    public void getAuthorizationEndpoint( String strAuthorizationEndpoint )
+    {
+        _strAuthorizationEndpoint = strAuthorizationEndpoint;
+    }
+
+    public String getTokenEndpoint( )
+    {
+        return _strTokenEndpoint;
+    }
+
+    @JsonProperty( "token_endpoint" )
+    public void setTokenEndpoint( String strTokenEndpoint )
+    {
+        _strTokenEndpoint = strTokenEndpoint;
+    }
+
+    public String getUserinfoEndpoint( )
+    {
+        return _strUserinfoEndpoint;
+    }
+
+    @JsonProperty( "userinfo_endpoint" )
+    public void setUserinfoEndpoint( String strUserinfoEndpoint )
+    {
+        _strUserinfoEndpoint = strUserinfoEndpoint;
+    }
+
+    public String getJwksURI( )
+    {
+        return _strJwksURI;
+    }
+
+    @JsonProperty( "jwks_uri" )
+    public void setJwksUri( String strJwksURI )
+    {
+        _strJwksURI = strJwksURI;
+    }
+
+    public String getRegistrationEndpoint( )
+    {
+        return _strRegistrationEndpoint;
+    }
+
+    @JsonProperty( "registration_endpoint" )
+    public void setRegistrationEndpoint( String strRegistrationEndpoint )
+    {
+        _strRegistrationEndpoint = strRegistrationEndpoint;
+    }
+
+    public String [ ] getScopesSupported( )
+    {
+        return _scopesSupported;
+    }
+
+    @JsonProperty( "scopes_supported" )
+    public void setScopesSupported( String [ ] scopesSupported )
+    {
+        this._scopesSupported = scopesSupported;
+    }
+
+    public String [ ] getResponseTypesSupported( )
+    {
+        return _responseTypesSupported;
+    }
+
+    @JsonProperty( "response_types_supported" )
+    public void setResponseTypesSupported( String [ ] responseTypesSupported )
+    {
+        this._responseTypesSupported = responseTypesSupported;
+    }
+
+    public String [ ] getResponseModesSupported( )
+    {
+        return _responseModesSupported;
+    }
+
+    @JsonProperty( "response_modes_supported" )
+    public void setResponseModesSupported( String [ ] responseModesSupported )
+    {
+        this._responseModesSupported = responseModesSupported;
+    }
+
+    public String [ ] getGrantTypesSupported( )
+    {
+        return _grantTypesSupported;
+    }
+
+    @JsonProperty( "grant_types_supported" )
+    public void setGrantTypesSupported( String [ ] grantTypesSupported )
+    {
+        this._grantTypesSupported = grantTypesSupported;
+    }
+
+    public String [ ] getAcrValuesSupported( )
+    {
+        return _acrValuesSupported;
+    }
+
+    @JsonProperty( "acr_values_supported" )
+    public void setAcrValuesSupported( String [ ] acrValuesSupported )
+    {
+        this._acrValuesSupported = acrValuesSupported;
+    }
+
+    public String [ ] getSubjectTypesSupported( )
+    {
+        return _subjectTypesSupported;
+    }
+
+    @JsonProperty( "subject_types_supported" )
+    public void setSubjectTypesSupported( String [ ] subjectTypesSupported )
+    {
+        this._subjectTypesSupported = subjectTypesSupported;
+    }
+
+    public String [ ] getIDTokenSigningAlgValuesSupported( )
+    {
+        return _idTokenSigningAlgValuesSupported;
+    }
+
+    @JsonProperty( "id_token_signing_alg_values_supported" )
+    public void setIDTokenSigningAlgValuesSupported( String [ ] idTokenSigningAlgValuesSupported )
+    {
+        this._idTokenSigningAlgValuesSupported = idTokenSigningAlgValuesSupported;
+    }
+
+    public String [ ] getIDTokenEncryptionAlgValuesSupported( )
+    {
+        return _idTokenEncryptionAlgValuesSupported;
+    }
+
+    @JsonProperty( "id_token_encryption_alg_values_supported" )
+    public void setIDTokenEncryptionAlgValuesSupported( String [ ] idTokenEncryptionAlgValuesSupported )
+    {
+        this._idTokenEncryptionAlgValuesSupported = idTokenEncryptionAlgValuesSupported;
+    }
+
+    public String [ ] getIDTokenEncryptionEncValuesSupported( )
+    {
+        return _idTokenEncryptionEncValuesSupported;
+    }
+
+    @JsonProperty( "id_token_encryption_enc_values_supported" )
+    public void setIDTokenEncryptionEncValuesSupported( String [ ] _idTokenEncryptionEncValuesSupported )
+    {
+        this._idTokenEncryptionEncValuesSupported = _idTokenEncryptionEncValuesSupported;
+    }
+
+    public String [ ] getUserinfoSigningAlgValuesSupported( )
+    {
+        return _userinfoSigningAlgValuesSupported;
+    }
+
+    @JsonProperty( "userinfo_signing_alg_values_supported" )
+    public void setUserinfoSigningAlgValuesSupported( String [ ] userinfoSigningAlgValuesSupported )
+    {
+        this._userinfoSigningAlgValuesSupported = userinfoSigningAlgValuesSupported;
+    }
+
+    public String [ ] getUserinfoEncryptionAlgValuesSupported( )
+    {
+        return _userinfoEncryptionAlgValuesSupported;
+    }
+
+    @JsonProperty( "userinfo_encryption_alg_values_supported" )
+    public void setUserinfoEncryptionAlgValuesSupported( String [ ] userinfoEncryptionAlgValuesSupported )
+    {
+        this._userinfoEncryptionAlgValuesSupported = userinfoEncryptionAlgValuesSupported;
+    }
+
+    public String [ ] getUserinfoEncryptionEncValuesSupported( )
+    {
+        return _userinfoEncryptionEncValuesSupported;
+    }
+
+    @JsonProperty( "userinfo_encryption_enc_values_supported" )
+    public void setUserinfoEncryptionEncValuesSupported( String [ ] userinfoEncryptionEncValuesSupported )
+    {
+        this._userinfoEncryptionEncValuesSupported = userinfoEncryptionEncValuesSupported;
+    }
+
+    public String [ ] getRequestObjectSigningAlgValuesSupported( )
+    {
+        return _requestObjectSigningAlgValuesSupported;
+    }
+
+    @JsonProperty( "request_object_signing_alg_values_supported" )
+    public void setRequestObjectSigningAlgValuesSupported( String [ ] requestObjectSigningAlgValuesSupported )
+    {
+        this._requestObjectSigningAlgValuesSupported = requestObjectSigningAlgValuesSupported;
+    }
+
+    public String [ ] getRequestObjectEncryptionAlgValuesSupported( )
+    {
+        return _requestObjectEncryptionAlgValuesSupported;
+    }
+
+    @JsonProperty( "request_object_encryption_alg_values_supported" )
+    public void setRequestObjectEncryptionAlgValuesSupported( String [ ] requestObjectEncryptionAlgValuesSupported )
+    {
+        this._requestObjectEncryptionAlgValuesSupported = requestObjectEncryptionAlgValuesSupported;
+    }
+
+    public String [ ] getRequestObjectEncryptionEncValuesSupported( )
+    {
+        return _requestObjectEncryptionEncValuesSupported;
+    }
+
+    @JsonProperty( "request_object_encryption_enc_values_supported" )
+    public void setRequestObjectEncryptionEncValuesSupported( String [ ] requestObjectEncryptionEncValuesSupported )
+    {
+        this._requestObjectEncryptionEncValuesSupported = requestObjectEncryptionEncValuesSupported;
+    }
+
+    public String [ ] getTokenEndpointAuthMethodsSupported( )
+    {
+        return _tokenEndpointAuthMethodsSupported;
+    }
+
+    @JsonProperty( "token_endpoint_auth_methods_supported" )
+    public void setTokenEndpointAuthMethodsSupported( String [ ] tokenEndpointAuthMethodsSupported )
+    {
+        this._tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethodsSupported;
+    }
+
+    public String [ ] getTokenEndpointAuthSigningAlgValuesSupported( )
+    {
+        return _tokenEndpointAuthSigningAlgValuesSupported;
+    }
+
+    @JsonProperty( "token_endpoint_auth_signing_alg_values_supported" )
+    public void setTokenEndpointAuthSigningAlgValuesSupported( String [ ] tokenEndpointAuthSigningAlgValuesSupported )
+    {
+        this._tokenEndpointAuthSigningAlgValuesSupported = tokenEndpointAuthSigningAlgValuesSupported;
+    }
+
+    public String [ ] getDisplayValuesSupported( )
+    {
+        return _displayValuesSupported;
+    }
+
+    @JsonProperty( "display_values_supported" )
+    public void setDisplayValuesSupported( String [ ] displayValuesSupported )
+    {
+        this._displayValuesSupported = displayValuesSupported;
+    }
+
+    public String [ ] getClaimTypesSupported( )
+    {
+        return _claimTypesSupported;
+    }
+
+    @JsonProperty( "claim_types_supported" )
+    public void setClaimTypesSupported( String [ ] claimTypesSupported )
+    {
+        this._claimTypesSupported = claimTypesSupported;
+    }
+
+    public String [ ] getClaimsSupported( )
+    {
+        return _claimsSupported;
+    }
+
+    @JsonProperty( "claims_supported" )
+    public void setClaimsSupported( String [ ] claimsSupported )
+    {
+        this._claimsSupported = claimsSupported;
+    }
+
+    public String getServiceDocumentation( )
+    {
+        return _serviceDocumentation;
+    }
+
+    @JsonProperty( "service_documentation" )
+    public void setServiceDocumentation( String serviceDocumentation )
+    {
+        this._serviceDocumentation = serviceDocumentation;
+    }
+
+    public String [ ] getClaimsLocalesSupported( )
+    {
+        return _claimsLocalesSupported;
+    }
+
+    @JsonProperty( "claims_locales_supported" )
+    public void setClaimsLocalesSupported( String [ ] claimsLocalesSupported )
+    {
+        this._claimsLocalesSupported = claimsLocalesSupported;
+    }
+
+    public String [ ] getUILocalesSupported( )
+    {
+        return _uiLocalesSupported;
+    }
+
+    @JsonProperty( "ui_locales_supported" )
+    public void setUILocalesSupported( String [ ] uiLocalesSupported )
+    {
+        this._uiLocalesSupported = uiLocalesSupported;
+    }
+
+    public boolean isClaimsParameterSupported( )
+    {
+        return _claimsParameterSupported;
+    }
+
+    @JsonProperty( "claims_parameter_supported" )
+    public void setClaimsParameterSupported( boolean claimsParameterSupported )
+    {
+        this._claimsParameterSupported = claimsParameterSupported;
+    }
+
+    public boolean isRequestParameterSupported( )
+    {
+        return _requestParameterSupported;
+    }
+
+    @JsonProperty( "request_parameter_supported" )
+    public void setRequestParameterSupported( boolean requestParameterSupported )
+    {
+        this._requestParameterSupported = requestParameterSupported;
+    }
+
+    public boolean isRequestUIRParameterSupported( )
+    {
+        return _requestUIRParameterSupported;
+    }
+
+    @JsonProperty( "request_uri_parameter_supported" )
+    public void setRequestUIRParameterSupported( boolean requestUIRParameterSupported )
+    {
+        this._requestUIRParameterSupported = requestUIRParameterSupported;
+    }
+
+    public boolean isRequireRequestUIRRegistration( )
+    {
+        return _requireRequestUIRRegistration;
+    }
+
+    @JsonProperty( "require_request_uri_registration" )
+    public void setRequireRequestUIRRegistration( boolean requireRequestUIRRegistration )
+    {
+        this._requireRequestUIRRegistration = requireRequestUIRRegistration;
+    }
+
+    public String getOpPolicyURI( )
+    {
+        return _opPolicyURI;
+    }
+
+    @JsonProperty( "op_policy_uri" )
+    public void setOpPolicyURI( String opPolicyURI )
+    {
+        this._opPolicyURI = opPolicyURI;
+    }
+
+    public String getOpTOSURI( )
+    {
+        return _opTOSURI;
+    }
+
+    @JsonProperty( "op_tos_uri" )
+    public void setOpTOSURI( String opTOSURI )
+    {
+        this._opTOSURI = opTOSURI;
+    }
+
+    public String getEndSessionEndpoint( )
+    {
+        return _strEndSessionEndpoint;
+    }
+
+    @JsonProperty( "end_session_endpoint" )
+    public void setEndSessionEndpoint( String strEndSessionEndpoint )
+    {
+        this._strEndSessionEndpoint = strEndSessionEndpoint;
+    }
+
+    /**
+     * Validate the configuration.
+     * 
+     * @param strExpectedIssuer
+     *            the expected issuer
+     * @throws NullPointerException
+     *             if a required parameter is absent
+     * @throws AppException
+     *             if another error is present
+     */
+    public void validate( String strExpectedIssuer )
+    {
+        validateIssuer( strExpectedIssuer );
+        validateAuthorizationEndpoint( );
+        validateTokenEndpoint( );
+        validateUserinfoEndpoint( );
+        validateJwksURI( );
+        validateRegistrationEndpoint( );
+        validateScopesSupported( );
+        validateResponseTypeSupported( );
+        validateSubjectTypesSupported( );
+        validateIDTokenSigningAlgValuesSupported( );
+        validateTokenEndpointAuthSigningAlgValuesSupported( );
+        validateEndSessionEndpoint( );
+    }
+
+    private void validateIssuer( String strExpectedIssuer )
+    {
+        Objects.requireNonNull( _strIssuer, "issuer is required" );
+        validateURI( _strIssuer, "issuer", false, false );
+        if ( !_strIssuer.equals( strExpectedIssuer ) )
+        {
+            throw new AppException( "Expected issuer " + strExpectedIssuer + ", but got " + _strIssuer );
+        }
+    }
+
+    private void validateAuthorizationEndpoint( )
+    {
+        Objects.requireNonNull( _strAuthorizationEndpoint, "Authorization endpoint is required" );
+        validateURI( _strAuthorizationEndpoint, "Authorization endpoint" );
+    }
+
+    private void validateTokenEndpoint( )
+    {
+        if ( _strTokenEndpoint == null )
+        {
+            // FIXME This is REQUIRED unless only the Implicit Flow is used
+            return;
+        }
+        validateURI( _strTokenEndpoint, "Token endpoint" );
+    }
+
+    private void validateUserinfoEndpoint( )
+    {
+        if ( _strUserinfoEndpoint == null )
+        {
+            return;
+        }
+        validateURI( _strUserinfoEndpoint, "Userinfo endpoint" );
+    }
+
+    private void validateJwksURI( )
+    {
+        Objects.requireNonNull( _strJwksURI, "JWKS URI is required" );
+        validateURI( _strJwksURI, "JWKS URI" );
+    }
+
+    private void validateRegistrationEndpoint( )
+    {
+        if ( _strRegistrationEndpoint == null )
+        {
+            return;
+        }
+        validateURI( _strRegistrationEndpoint, "Registration endpoint" );
+    }
+
+    private void validateScopesSupported( )
+    {
+        // The server MUST support the openid scope value. Servers MAY choose not to advertise some supported scope values even when this parameter is used,
+        // although those defined in [OpenID.Core] SHOULD be listed, if supported.
+    }
+
+    private void validateResponseTypeSupported( )
+    {
+        Objects.requireNonNull( _responseTypesSupported, "Response types supported is required" );
+        for ( String type : _responseTypesSupported )
+        {
+            Objects.requireNonNull( type, "response type must not be null" );
+        }
+    }
+
+    private void validateSubjectTypesSupported( )
+    {
+        Objects.requireNonNull( _subjectTypesSupported, "Subject types supported is required" );
+        for ( String type : _subjectTypesSupported )
+        {
+            Objects.requireNonNull( type, "subject type must not be null" );
+        }
+    }
+
+    private void validateTokenEndpointAuthSigningAlgValuesSupported( )
+    {
+        if ( _tokenEndpointAuthSigningAlgValuesSupported == null )
+        {
+            return;
+        }
+        if ( Arrays.stream( _tokenEndpointAuthSigningAlgValuesSupported ).anyMatch( alg -> "none".equals( alg ) ) )
+        {
+            throw new AppException( "The algorithm none MUST NOT be used for the token endpoint auth signing alg values supported" );
+        }
+    }
+
+    private void validateEndSessionEndpoint( )
+    {
+        if ( _strEndSessionEndpoint == null )
+        {
+            return;
+        }
+        validateURI( _strEndSessionEndpoint, "end session endpoint" );
+    }
+
+    private void validateIDTokenSigningAlgValuesSupported( )
+    {
+        Objects.requireNonNull( _idTokenSigningAlgValuesSupported, "ID Token signing alg values supported is required" );
+        if ( Arrays.stream( _idTokenSigningAlgValuesSupported ).noneMatch( alg -> "RS256".equals( alg ) ) )
+        {
+            throw new AppException( "The algorithm RS256 MUST be included in ID Token signing alg values supported" );
+        }
+    }
+
+    private void validateURI( String strURI, String strFieldName )
+    {
+        validateURI( strURI, strFieldName, true, true );
+    }
+
+    private void validateURI( String strURI, String strFieldName, boolean queryAllowed, boolean fragmentAllowed )
+    {
+        try
+        {
+            URI theURI = new URI( strURI );
+            if ( !theURI.getScheme( ).equals( "https" ) )
+            {
+                throw new AppException( strFieldName + " must be a URL using the https scheme" );
+            }
+            if ( !queryAllowed && theURI.getQuery( ) != null )
+            {
+                throw new AppException( strFieldName + " must be a URL with no query component" );
+            }
+            if ( !fragmentAllowed && theURI.getFragment( ) != null )
+            {
+                throw new AppException( strFieldName + " must be a URL with no fragment  component" );
+            }
+        }
+        catch( URISyntaxException e )
+        {
+            throw new AppException( "Unable to validate URI <" + strURI + "> for field " + strFieldName + ": " + e.getMessage( ), e );
+        }
+    }
+}

--- a/src/java/fr/paris/lutece/plugins/oauth2/jwt/JjwtJWTParser.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/jwt/JjwtJWTParser.java
@@ -85,7 +85,7 @@ public class JjwtJWTParser implements JWTParser
 
             JwtParser parser = parserBuilder.build( );
             Claims claims;
-            if ( serverConfig == null || serverConfig.getSignatureAlgorithmName( ) == null )
+            if ( serverConfig == null || serverConfig.getSignatureAlgorithmNames( ) == null )
             {
                 // claims should be unsigned
                 Jwt<Header, Claims> jwt = parser.parse( strCompactJwt ).accept( Jwt.UNSECURED_CLAIMS );
@@ -95,9 +95,9 @@ public class JjwtJWTParser implements JWTParser
             {
                 // claims should be signed
                 Jws<Claims> jws = parser.parse( strCompactJwt ).accept( Jws.CLAIMS );
-                if ( !serverConfig.getSignatureAlgorithmName( ).equals( jws.getHeader( ).getAlgorithm( ) ) )
+                if ( !serverConfig.getSignatureAlgorithmNames( ).contains( jws.getHeader( ).getAlgorithm( ) ) )
                 {
-                    throw new TokenValidationException( "Expected alg <" + serverConfig.getSignatureAlgorithmName( ) + "> but got <" + jws.getHeader( ).getAlgorithm( ) + ">" );
+                    throw new TokenValidationException( "Expected alg is one of <" + serverConfig.getSignatureAlgorithmNames( ) + "> but got <" + jws.getHeader( ).getAlgorithm( ) + ">" );
                 }
                 claims = jws.getPayload( );
             }

--- a/src/java/fr/paris/lutece/plugins/oauth2/jwt/JjwtJWTParser.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/jwt/JjwtJWTParser.java
@@ -85,7 +85,7 @@ public class JjwtJWTParser implements JWTParser
 
             JwtParser parser = parserBuilder.build( );
             Claims claims;
-            if ( serverConfig == null || serverConfig.getSignatureAlgorithmNames( ) == null )
+            if ( serverConfig == null || serverConfig.getIDTokenSignatureAlgorithmNames( ) == null )
             {
                 // claims should be unsigned
                 Jwt<Header, Claims> jwt = parser.parse( strCompactJwt ).accept( Jwt.UNSECURED_CLAIMS );
@@ -95,9 +95,9 @@ public class JjwtJWTParser implements JWTParser
             {
                 // claims should be signed
                 Jws<Claims> jws = parser.parse( strCompactJwt ).accept( Jws.CLAIMS );
-                if ( !serverConfig.getSignatureAlgorithmNames( ).contains( jws.getHeader( ).getAlgorithm( ) ) )
+                if ( !serverConfig.getIDTokenSignatureAlgorithmNames( ).contains( jws.getHeader( ).getAlgorithm( ) ) )
                 {
-                    throw new TokenValidationException( "Expected alg is one of <" + serverConfig.getSignatureAlgorithmNames( ) + "> but got <" + jws.getHeader( ).getAlgorithm( ) + ">" );
+                    throw new TokenValidationException( "Expected alg is one of <" + serverConfig.getIDTokenSignatureAlgorithmNames( ) + "> but got <" + jws.getHeader( ).getAlgorithm( ) + ">" );
                 }
                 claims = jws.getPayload( );
             }

--- a/src/java/fr/paris/lutece/plugins/oauth2/jwt/KeyLocator.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/jwt/KeyLocator.java
@@ -51,10 +51,18 @@ public class KeyLocator extends LocatorAdapter<Key>
     private final String _strJwksEndpointUri;
     private final HttpAccess _httpAccess;
 
-    public KeyLocator( String strJwksEndpointUri )
+    /**
+     * Constructs a Key Locator
+     * 
+     * @param strJwksEndpointUri
+     *            the URI of the JKWS resource
+     * @param httpAccess
+     *            the httpAccess for fetching the file
+     */
+    public KeyLocator( String strJwksEndpointUri, HttpAccess httpAccess )
     {
         _strJwksEndpointUri = strJwksEndpointUri;
-        _httpAccess = new HttpAccess( );
+        _httpAccess = httpAccess;
     }
 
     @Override

--- a/src/java/fr/paris/lutece/plugins/oauth2/jwt/MitreJWTParser.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/jwt/MitreJWTParser.java
@@ -98,13 +98,13 @@ public class MitreJWTParser implements JWTParser
 
         Algorithm tokenAlg = jwt.getHeader( ).getAlgorithm( );
 
-        Algorithm clientAlg = JWSAlgorithm.parse( serverConfig.getSignatureAlgorithmName( ) );
-
-        if ( serverConfig.getSignatureAlgorithmName( ) != null )
+        if ( serverConfig.getSignatureAlgorithmNames( ) != null )
         {
-            if ( !clientAlg.equals( tokenAlg ) )
+            if ( serverConfig.getSignatureAlgorithmNames( ).stream( ).map( algName -> JWSAlgorithm.parse( algName ) )
+                    .noneMatch( alg -> tokenAlg.equals( alg ) ) )
             {
-                throw new TokenValidationException( "Token algorithm " + tokenAlg + " does not match expected algorithm " + clientAlg );
+                throw new TokenValidationException(
+                        "Token algorithm " + tokenAlg + " does not match any expected algorithm " + serverConfig.getSignatureAlgorithmNames( ) );
             }
         }
 
@@ -112,7 +112,7 @@ public class MitreJWTParser implements JWTParser
         {
             logger.debug( "ID token is a Plain JWT" );
 
-            if ( serverConfig.getSignatureAlgorithmName( ) != null )
+            if ( serverConfig.getSignatureAlgorithmNames( ) != null )
             {
                 throw new TokenValidationException( "Unsigned ID tokens can only be used if explicitly configured in client." );
             }

--- a/src/java/fr/paris/lutece/plugins/oauth2/jwt/MitreJWTParser.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/jwt/MitreJWTParser.java
@@ -98,13 +98,13 @@ public class MitreJWTParser implements JWTParser
 
         Algorithm tokenAlg = jwt.getHeader( ).getAlgorithm( );
 
-        if ( serverConfig.getSignatureAlgorithmNames( ) != null )
+        if ( serverConfig.getIDTokenSignatureAlgorithmNames( ) != null )
         {
-            if ( serverConfig.getSignatureAlgorithmNames( ).stream( ).map( algName -> JWSAlgorithm.parse( algName ) )
+            if ( serverConfig.getIDTokenSignatureAlgorithmNames( ).stream( ).map( algName -> JWSAlgorithm.parse( algName ) )
                     .noneMatch( alg -> tokenAlg.equals( alg ) ) )
             {
                 throw new TokenValidationException(
-                        "Token algorithm " + tokenAlg + " does not match any expected algorithm " + serverConfig.getSignatureAlgorithmNames( ) );
+                        "Token algorithm " + tokenAlg + " does not match any expected algorithm " + serverConfig.getIDTokenSignatureAlgorithmNames( ) );
             }
         }
 
@@ -112,7 +112,7 @@ public class MitreJWTParser implements JWTParser
         {
             logger.debug( "ID token is a Plain JWT" );
 
-            if ( serverConfig.getSignatureAlgorithmNames( ) != null )
+            if ( serverConfig.getIDTokenSignatureAlgorithmNames( ) != null )
             {
                 throw new TokenValidationException( "Unsigned ID tokens can only be used if explicitly configured in client." );
             }

--- a/src/java/fr/paris/lutece/plugins/oauth2/service/CachingHttpAccessService.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/service/CachingHttpAccessService.java
@@ -1,0 +1,23 @@
+package fr.paris.lutece.plugins.oauth2.service;
+
+import org.apache.hc.client5.http.impl.cache.CachingHttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+
+import fr.paris.lutece.util.httpaccess.HttpAccessService;
+import fr.paris.lutece.util.httpaccess.HttpClientConfiguration;
+
+public class CachingHttpAccessService extends HttpAccessService
+{
+
+    public CachingHttpAccessService( HttpClientConfiguration httpClientConfiguration )
+    {
+        super( httpClientConfiguration );
+    }
+
+    @Override
+    protected HttpClientBuilder getHttpClientBuilder( )
+    {
+        return CachingHttpClientBuilder.create();
+    }
+
+}

--- a/src/site/fr/xdoc/index.xml
+++ b/src/site/fr/xdoc/index.xml
@@ -32,16 +32,38 @@
         <section name="Installation">
         <subsection name="Configuration">
        <p>
-           Configurer le fichier de context du plugin (WEB-INF/conf/plugins/oauth2_context.xml).
+           Configurer le fichier de context du plugin (WEB-INF/conf/plugins/oauth2_context.xml). 
+        </p>
+        <p>Pour la configuration client, utilisez une configuration du type</p>
+        <div class="source">
+<pre>           
+    &lt;bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf"&gt;
+        &lt;property name="clientId" value=" **** à renseigner **** "/&gt;
+        &lt;property name="clientSecret" value=" **** à renseigner **** "/&gt;
+        &lt;property name="redirectUri" value=" **** à renseigner **** "/&gt;
+    &lt;/bean&gt;       
+</pre>
+</div>
+    <p>
+           Pour la configuration serveur, si le serveur OAuth supporte OpenID Connect, alors
+           seul le paramètre <code>issuer</code> est requis, en utilisant la class de configuration
+           <code>fr.paris.lutece.plugins.oauth2.business.OIDCAuthServerConf</code>
        </p>
+       <div class="source">
+<pre>
+    &lt;bean id="oauth2.server" class="fr.paris.lutece.plugins.oauth2.business.OIDCAuthServerConf"&gt;
+        &lt;property name="issuer" value="${oauth2.issuer} "/&gt;
+    &lt;/bean&gt; 
+</pre>
+        </div>
+        <p>La variable <code>oauth2.issuer</code> peut être définie dans un fichier de properties afin d'être adaptée aux différents environnements.</p>
         <p>   
-           Il faut notamment paramétrer :
+           Une configuration directe est également possible, en utilisant la classe <code>fr.paris.lutece.plugins.oauth2.business.AuthServerConf</code> : 
             <ul>
                 <li>Les adresses des WebServices la plate-forme Oauth2 cible (end points)</li>
-                <li>Vos identifiants  (id, secret) qui vous auront été fournit par le service oauth2 utilisé</li>
                 <li>Si le serveur utilise JWT et que les tokens sont signés, alors le paramètre
-                signatureAlgorithmName soit être renseigné. Si les tokens ne
-                sont pas signés, alors le paramètre signatureAlgorithmName ne doit pas être renseigné</li>
+                IDTokenSignatureAlgorithmNames soit être renseigné. Si les tokens ne
+                sont pas signés, alors le paramètre IDTokenSignatureAlgorithmNames ne doit pas être renseigné</li>
                 <li>Si le paramètre jwksEndpointUri est renseigné, les clefs de signature des token sont
                 téléchargées depuis cette adresse, qui doit pointer vers un fichier JWKS.</li>
                 <li>L'adresse du Callback du plugin (NB : Cette adresse doit être enregistrée et 
@@ -63,18 +85,14 @@
         &lt;property name="tokenEndpointUri" value=" **** à renseigner **** "/&gt;
         &lt;property name="logoutEndpointUri" value=" **** à renseigner **** "/&gt;
         &lt;property name="enableJwtParser" value="****true si le serveur utilise JWT ****" /&gt;
-        &lt;property name="signatureAlgorithmName" value="HS512"/&gt;
+        &lt;property name="IDTokenSignatureAlgorithmNames"&gt;
+            &lt;set&gt;&lt;value&gt;HS512&lt;value&gt;&lt;/set&gt;
+        &lt;/property&gt;
         &lt;property name="jwksEndpointUri" value=" **** à renseigner **** "/&gt;
-    &lt;/bean&gt; 
-    
-    &lt;bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf"&gt;
-        &lt;property name="clientId" value=" **** à renseigner **** "/&gt;
-        &lt;property name="clientSecret" value=" **** à renseigner **** "/&gt;
-        &lt;property name="redirectUri" value=" **** à renseigner **** "/&gt;
-    &lt;/bean&gt;       
+    &lt;/bean&gt;  
     
     &lt;bean id="oauth2.callbackHandler" class="fr.paris.lutece.plugins.oauth2.web.CallbackHandler" &gt;
-      ;&lt;property name="authServerConf" ref="oauth2.server"&gt;
+       &lt;property name="authServerConf" ref="oauth2.server"&gt;
        &lt;property name="authClientConf" ref="oauth2.client"&gt;
        &lt;property name="jWTParser" ref="oauth2.jWTParser""&gt;
     &lt;/bean&gt;      

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -32,16 +32,38 @@
         <section name="Installation">
         <subsection name="Configuration">
        <p>
-           Configurer le fichier de context du plugin (WEB-INF/conf/plugins/oauth2_context.xml).
+           Configurer le fichier de context du plugin (WEB-INF/conf/plugins/oauth2_context.xml). 
+        </p>
+        <p>Pour la configuration client, utilisez une configuration du type</p>
+        <div class="source">
+<pre>           
+    &lt;bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf"&gt;
+        &lt;property name="clientId" value=" **** à renseigner **** "/&gt;
+        &lt;property name="clientSecret" value=" **** à renseigner **** "/&gt;
+        &lt;property name="redirectUri" value=" **** à renseigner **** "/&gt;
+    &lt;/bean&gt;       
+</pre>
+</div>
+    <p>
+           Pour la configuration serveur, si le serveur OAuth supporte OpenID Connect, alors
+           seul le paramètre <code>issuer</code> est requis, en utilisant la class de configuration
+           <code>fr.paris.lutece.plugins.oauth2.business.OIDCAuthServerConf</code>
        </p>
+       <div class="source">
+<pre>
+    &lt;bean id="oauth2.server" class="fr.paris.lutece.plugins.oauth2.business.OIDCAuthServerConf"&gt;
+        &lt;property name="issuer" value="${oauth2.issuer} "/&gt;
+    &lt;/bean&gt; 
+</pre>
+        </div>
+        <p>La variable <code>oauth2.issuer</code> peut être définie dans un fichier de properties afin d'être adaptée aux différents environnements.</p>
         <p>   
-           Il faut notamment paramétrer :
+           Une configuration directe est également possible, en utilisant la classe <code>fr.paris.lutece.plugins.oauth2.business.AuthServerConf</code> : 
             <ul>
                 <li>Les adresses des WebServices la plate-forme Oauth2 cible (end points)</li>
-                <li>Vos identifiants  (id, secret) qui vous auront été fournit par le service oauth2 utilisé</li>
                 <li>Si le serveur utilise JWT et que les tokens sont signés, alors le paramètre
-                signatureAlgorithmName soit être renseigné. Si les tokens ne
-                sont pas signés, alors le paramètre signatureAlgorithmName ne doit pas être renseigné</li>
+                IDTokenSignatureAlgorithmNames soit être renseigné. Si les tokens ne
+                sont pas signés, alors le paramètre IDTokenSignatureAlgorithmNames ne doit pas être renseigné</li>
                 <li>Si le paramètre jwksEndpointUri est renseigné, les clefs de signature des token sont
                 téléchargées depuis cette adresse, qui doit pointer vers un fichier JWKS.</li>
                 <li>L'adresse du Callback du plugin (NB : Cette adresse doit être enregistrée et 
@@ -63,18 +85,14 @@
         &lt;property name="tokenEndpointUri" value=" **** à renseigner **** "/&gt;
         &lt;property name="logoutEndpointUri" value=" **** à renseigner **** "/&gt;
         &lt;property name="enableJwtParser" value="****true si le serveur utilise JWT ****" /&gt;
-        &lt;property name="signatureAlgorithmName" value="HS512"/&gt;
+        &lt;property name="IDTokenSignatureAlgorithmNames"&gt;
+            &lt;set&gt;&lt;value&gt;HS512&lt;value&gt;&lt;/set&gt;
+        &lt;/property&gt;
         &lt;property name="jwksEndpointUri" value=" **** à renseigner **** "/&gt;
-    &lt;/bean&gt; 
-    
-    &lt;bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf"&gt;
-        &lt;property name="clientId" value=" **** à renseigner **** "/&gt;
-        &lt;property name="clientSecret" value=" **** à renseigner **** "/&gt;
-        &lt;property name="redirectUri" value=" **** à renseigner **** "/&gt;
-    &lt;/bean&gt;       
+    &lt;/bean&gt;  
     
     &lt;bean id="oauth2.callbackHandler" class="fr.paris.lutece.plugins.oauth2.web.CallbackHandler" &gt;
-      ;&lt;property name="authServerConf" ref="oauth2.server"&gt;
+       &lt;property name="authServerConf" ref="oauth2.server"&gt;
        &lt;property name="authClientConf" ref="oauth2.client"&gt;
        &lt;property name="jWTParser" ref="oauth2.jWTParser""&gt;
     &lt;/bean&gt;      

--- a/src/test/java/fr/paris/lutece/plugins/oauth2/service/jwt/JjwtJWTParserTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/oauth2/service/jwt/JjwtJWTParserTest.java
@@ -54,6 +54,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Jjwt JWTParser Test
@@ -83,7 +84,7 @@ public class JjwtJWTParserTest
         clientConfig.setClientSecret( SECRET );
 
         AuthServerConf serverConfig = new AuthServerConf( );
-        serverConfig.setSignatureAlgorithmName( "HS512" );
+        serverConfig.setIDTokenSignatureAlgorithmNames( Set.of( "HS512" ) );
         String strStoredNonce = NONCE;
         Logger logger = Logger.getLogger( Constants.LOGGER_OAUTH2 );
         JjwtJWTParser instance = new JjwtJWTParser( );
@@ -104,7 +105,7 @@ public class JjwtJWTParserTest
         clientConfig.setClientSecret( SECRET );
 
         AuthServerConf serverConfig = new AuthServerConf( );
-        serverConfig.setSignatureAlgorithmName( "HS256" );
+        serverConfig.setIDTokenSignatureAlgorithmNames( Set.of( "HS256" ) );
         String strStoredNonce = NONCE;
         Logger logger = Logger.getLogger( Constants.LOGGER_OAUTH2 );
         JjwtJWTParser instance = new JjwtJWTParser( );
@@ -161,7 +162,7 @@ public class JjwtJWTParserTest
         clientConfig.setClientSecret( SECRET );
 
         AuthServerConf serverConfig = new AuthServerConf( );
-        serverConfig.setSignatureAlgorithmName( "HS512" );
+        serverConfig.setIDTokenSignatureAlgorithmNames( Set.of( "HS512" ) );
         String strStoredNonce = NONCE;
         Logger logger = Logger.getLogger( Constants.LOGGER_OAUTH2 );
         JjwtJWTParser instance = new JjwtJWTParser( );

--- a/src/test/java/fr/paris/lutece/plugins/oauth2/service/jwt/JjwtJWTParserTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/oauth2/service/jwt/JjwtJWTParserTest.java
@@ -39,13 +39,14 @@ import fr.paris.lutece.plugins.oauth2.business.Token;
 import fr.paris.lutece.plugins.oauth2.jwt.JjwtJWTParser;
 import fr.paris.lutece.plugins.oauth2.jwt.TokenValidationException;
 import fr.paris.lutece.plugins.oauth2.web.Constants;
-
+import fr.paris.lutece.portal.service.util.AppPathService;
+import fr.paris.lutece.portal.service.util.AppPropertiesService;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 
 import org.apache.log4j.Logger;
-
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.fail;
@@ -68,6 +69,14 @@ public class JjwtJWTParserTest
     private static final String IDP = "dgfip";
     private static final String NONCE = "12344354597459";
     private static final String ACR = "eidas2";
+
+    @BeforeClass
+    public static void initLutece( )
+    {
+        // fake initialization
+        AppPathService.init( "" );
+        AppPropertiesService.init( "" );
+    }
 
     /**
      * Test of parseJWT method, of class JjwtJWTParser.

--- a/webapp/WEB-INF/conf/plugins/oauth2.properties
+++ b/webapp/WEB-INF/conf/plugins/oauth2.properties
@@ -1,4 +1,4 @@
 ################################################################################
 # Fichier de configuration du plugin Oauth2
 
-
+oauth2.issuer=https://v70-auth.paris.fr/auth/realms/paris

--- a/webapp/WEB-INF/conf/plugins/oauth2_context.xml
+++ b/webapp/WEB-INF/conf/plugins/oauth2_context.xml
@@ -9,15 +9,21 @@
        http://www.springframework.org/schema/context/spring-context-3.0.xsd
        http://www.springframework.org/schema/tx
        http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
-    
-    <bean id="oauth2.server" class="fr.paris.lutece.plugins.oauth2.business.AuthServerConf">
+
+    <bean id="oauth2.server" class="fr.paris.lutece.plugins.oauth2.business.OIDCAuthServerConf">
+        <property name="issuer" value="${oauth2.issuer} "/>
+    </bean> 
+
+    <!-- <bean id="oauth2.server" class="fr.paris.lutece.plugins.oauth2.business.AuthServerConf">
         <property name="issuer" value="http://fcp.integ01.dev-oauth2.fr"/>
         <property name="authorizationEndpointUri" value="https://fcp.integ01.dev-oauth2.fr/api/v1/authorize"/>
         <property name="tokenEndpointUri" value="https://fcp.integ01.dev-oauth2.fr/api/v1/token"/>
         <property name="logoutEndpointUri" value="https://fcp.integ01.dev-oauth2.fr/api/v1/logout"/>
         <property name="enableJwtParser" value="true"/>
-        <property name="signatureAlgorithmName" value="HS512"/>
-      </bean> 
+        <property name="IDTokenSignatureAlgorithmNames">
+            <set><value>HS512<value></set>
+        </property>
+      </bean> --> 
     
     <bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf">
         <property name="clientId" value=""/>


### PR DESCRIPTION
Create a new AuthServerConf subclass for which only the issuer is mandatory. The configuration is then fetched from the well-known URL.
Use a caching Httpclient so that the files are not fetched on each access.