### PR TITLE
LUT-29763: Bump global-pom to 7.0.1 to up java requirement to 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>lutece-global-pom</artifactId>
         <groupId>fr.paris.lutece.tools</groupId>
-        <version>6.0.0</version>
+        <version>7.0.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
The java.util.Set#of method, which has been introduced in java 9, has been used as part of LUT-29463. Since Lutece is requiring java 11 as of Lutece core 7.1.0, the requirement can be passed down to this plugin.