### PR TITLE
LUT-29769: Add a method to tell if a token is expired

### DIFF
--- a/src/java/fr/paris/lutece/plugins/oauth2/business/Token.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/business/Token.java
@@ -33,6 +33,8 @@
  */
 package fr.paris.lutece.plugins.oauth2.business;
 
+import java.time.Instant;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -51,6 +53,28 @@ public class Token
     private IDToken _idToken;
     @JsonProperty( "refresh_token" )
     private String _strRefreshToken;
+
+    private final Instant _creationTime;
+
+    /**
+     * Constructs a token
+     */
+    public Token( )
+    {
+        _creationTime = Instant.now( );
+    }
+
+    /**
+     * Constructs a token with a specific creation time
+     * 
+     * @param creationTime
+     *            the token creation time
+     * @since 2.0.0
+     */
+    public Token( Instant creationTime )
+    {
+        _creationTime = creationTime;
+    }
 
     /**
      * Returns the AccessToken
@@ -179,6 +203,28 @@ public class Token
     }
 
     /**
+     * Access the token creation time
+     * 
+     * @return the token creation time
+     * @since 2.0.0
+     */
+    public Instant getCreationTime( )
+    {
+        return _creationTime;
+    }
+
+    /**
+     * Is the token expired
+     * 
+     * @return <code>true</code> if the token is expired
+     * @since 2.0.0
+     */
+    public boolean isExpired( )
+    {
+        return _creationTime.plusSeconds( _nExpiresIn ).isBefore( Instant.now( ) );
+    }
+
+    /**
      * {@inheritDoc }
      */
     @Override
@@ -186,7 +232,8 @@ public class Token
     {
         StringBuilder sbToken = new StringBuilder( );
         sbToken.append( "Token infos : \n  access_token : " ).append( _strAccessToken ).append( "\n  expires_in : " ).append( _nExpiresIn )
-                .append( "\n  token_type : " ).append( _strTokenType ).append( "\n  id_token : " ).append( _strIdToken ).append( "\n\n" );
+                .append( "\n  token_type : " ).append( _strTokenType ).append( "\n  id_token : " ).append( _strIdToken )
+                .append( "\n creation time: " ).append( _creationTime ).append( "\n\n" );
 
         return sbToken.toString( );
     }

--- a/src/java/fr/paris/lutece/plugins/oauth2/service/MapperService.java
+++ b/src/java/fr/paris/lutece/plugins/oauth2/service/MapperService.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 
 /**
  * JSON Mapper utils
@@ -74,6 +75,26 @@ public final class MapperService
     public static <T> T parse( String strJson, Class<T> t ) throws IOException
     {
         return _mapper.readValue( strJson, t );
+    }
+
+    /**
+     * parse the JSON for an existing bean
+     * 
+     * @param <T>
+     *            The Bean class
+     * @param strJson
+     *            The JSON
+     * @param bean
+     *            The bean
+     * @return The bean
+     * @throws IOException
+     *             if an error occurs
+     * @since 2.0.0
+     */
+    public static <T> T parse( String strJson, T bean ) throws IOException
+    {
+        ObjectReader reader = _mapper.readerForUpdating( bean );
+        return reader.readValue( strJson );
     }
 
 }

--- a/webapp/WEB-INF/conf/plugins/oauth2_context.xml
+++ b/webapp/WEB-INF/conf/plugins/oauth2_context.xml
@@ -35,7 +35,9 @@
         By default the redirect Url is the Oauth2 Servlet URL servlet/plugins/oauth2/callback
         <property name="redirectUri" value="http/locaclhost:8080/lutece/servlet/plugins/oauth2/callback"/>
         -->
-    </bean>       
+    </bean>
+
+    <bean id="oauth2.tokenService" class="fr.paris.lutece.plugins.oauth2.service.TokenService" />
     
     <bean id="oauth2.callbackHandler" class="fr.paris.lutece.plugins.oauth2.web.CallbackHandler" >
         <property name="authServerConf" ref="oauth2.server"/>


### PR DESCRIPTION
Add support for setting the creation time before the request to the token endpoint is made, so that the expiration is determined pessimistically. Expiration is determined with reference to the token emission time, which is between the moment the request is made and the response is received.

Add a test. To make testing more convenient, the token service is switched to be spring managed with dependencies injected.