### PR TITLE
LUT-29463: Fix typos in context file

### DIFF
--- a/webapp/WEB-INF/conf/plugins/oauth2.properties
+++ b/webapp/WEB-INF/conf/plugins/oauth2.properties
@@ -2,3 +2,7 @@
 # Fichier de configuration du plugin Oauth2
 
 oauth2.issuer=https://v70-auth.paris.fr/auth/realms/paris
+# client id can be set here or taken from the tomcat context, see https://tomcat.apache.org/tomcat-9.0-doc/config/context.html#Environment_Entries
+#oauth2.clientId=<id>
+# client secret can be set here or taken from the tomcat context, see https://tomcat.apache.org/tomcat-9.0-doc/config/context.html#Environment_Entries
+#oauth2.clientSecret=<secret>

--- a/webapp/WEB-INF/conf/plugins/oauth2_context.xml
+++ b/webapp/WEB-INF/conf/plugins/oauth2_context.xml
@@ -11,7 +11,7 @@
        http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
 
     <bean id="oauth2.server" class="fr.paris.lutece.plugins.oauth2.business.OIDCAuthServerConf">
-        <property name="issuer" value="${oauth2.issuer} "/>
+        <property name="issuer" value="${oauth2.issuer}"/>
     </bean> 
 
     <!-- <bean id="oauth2.server" class="fr.paris.lutece.plugins.oauth2.business.AuthServerConf">
@@ -26,14 +26,14 @@
       </bean> --> 
     
     <bean id="oauth2.client" class="fr.paris.lutece.plugins.oauth2.business.AuthClientConf">
-        <property name="clientId" value=""/>
-        <property name="clientSecret" value=""/>
+        <property name="clientId" value="${oauth2.clientId}"/>
+        <property name="clientSecret" value="${oauth2.clientSecret}"/>
         <property name="public" value="false"/>
         <property name="pkce" value="false"/>
         
         <!--
         By default the redirect Url is the Oauth2 Servlet URL servlet/plugins/oauth2/callback
-        <property name="redirectUri" value="http/locaclhost:8080/lutece/servlet/plugins/oauth2/callback"/>
+        <property name="redirectUri" value="http://localhost:8080/lutece/servlet/plugins/oauth2/callback"/>
         -->
     </bean>       
     


### PR DESCRIPTION
Fix a typo for the issuer property.
Suggest that clientID and clientSecret can be configured via properties or the tomcat context.

Fix typo in redirect URI example.